### PR TITLE
Add macOS installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ You can install `hexyl` from [this AUR package](https://aur.archlinux.org/packag
 yaourt -S hexyl
 ```
 
+### On macOS
+
+```
+brew install hexyl
+```
 
 ### On other distributions
 


### PR DESCRIPTION
As hexyl was added into Homebrew repository, I put the installation guide for macOS.
https://github.com/Homebrew/homebrew-core/commit/8322ec31e6d63e16aac9db318c28e8acec485103